### PR TITLE
Fix message mutation bug

### DIFF
--- a/backend/server.ts
+++ b/backend/server.ts
@@ -20,14 +20,22 @@ const start = async (modelName: string, userMessage?: string) => {
 
     if (!modelConfig) throw new Error(`Model ${modelName} not found`);
 
-    const {name, model, messages, initOptions, completionOptions} = modelConfig;
+    const {name, model, messages: modelMessages, initOptions, completionOptions} = modelConfig;
+
+    // Clone messages so we don't mutate the config across requests
+    const messages: PromptMessage[] = JSON.parse(JSON.stringify(modelMessages));
 
     console.log(name)
 
     const initializedModel = await initModel(model, initOptions);
 
     if (userMessage && Array.isArray(messages)) {
-        messages.find((message) => message.role === 'user').content += userMessage;
+        const userMsg = messages.find((message) => message.role === 'user');
+        if (userMsg) {
+            userMsg.content += userMessage;
+        } else {
+            messages.push({ role: 'user', content: userMessage });
+        }
     }
 
     const response = await createCompletion(initializedModel, messages as PromptMessage[], completionOptions);


### PR DESCRIPTION
## Summary
- ensure each request clones model messages before appending user input
- add fallback if user message entry is missing

## Testing
- `npm test` *(fails: Missing script)*
- `npx tsc --noEmit server.ts` *(fails: network access for dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_684c8f774268832b9c9e87aebfca6a85