### PR TITLE
Add script to run both services

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,12 @@
 # DigitalPressAI
+
+This project contains a Bun-based backend and frontend. To simplify running both
+servers during development, use the provided `start.sh` script from the project
+root:
+
+```bash
+./start.sh
+```
+
+The backend listens on `http://localhost:8080` and the frontend on
+`http://localhost:3000`.

--- a/backend/README.md
+++ b/backend/README.md
@@ -6,11 +6,14 @@ To install dependencies:
 bun install
 ```
 
-To run:
+The backend can be started on its own with:
 
 ```bash
 bun run server.ts
 ```
+
+During development it is usually launched together with the frontend via
+`../start.sh`.
 
 ## Database
 

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -6,15 +6,20 @@ To install dependencies:
 bun install
 ```
 
-To run the story generator UI you need both the backend and the frontend running.
+To run the story generator UI you can start both servers at once from the project
+root:
 
-Start the backend from the project root:
+```bash
+./start.sh
+```
+
+Alternatively, you can run them in separate terminals as follows:
 
 ```bash
 bun run ../backend/server.ts
 ```
 
-In another terminal start the frontend:
+and
 
 ```bash
 bun run index.ts

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+# Start backend and frontend servers simultaneously
+# Usage: ./start.sh
+
+set -e
+
+# Start backend
+bun run backend/server.ts &
+BACKEND_PID=$!
+
+# Start frontend
+bun run frontend/index.ts &
+FRONTEND_PID=$!
+
+# Forward termination signals to child processes
+trap 'kill $BACKEND_PID $FRONTEND_PID' SIGINT SIGTERM
+
+# Wait for both processes to exit
+wait $BACKEND_PID $FRONTEND_PID


### PR DESCRIPTION
## Summary
- add `start.sh` for running backend and frontend simultaneously
- document usage in main README and sub-project READMEs

## Testing
- `bash -n start.sh`

------
https://chatgpt.com/codex/tasks/task_e_684c97a23de4832b9b312cb2d5dcaf1e